### PR TITLE
fix: Add gfortran to Ubuntu install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Please note that before starting any major work, open an issue describing what y
   brew install gcc
 
   # Linux Users
-  sudo apt install build-essential       
+  sudo apt install build-essential gfortran
   ```
 - All developments are done via [*python-poetry*](https://python-poetry.org/). To begin with, first install `poetry` following the [*installation documentation*](https://python-poetry.org/docs/#installation) depending on your operating system.
 - You can also easily [*manage your Python environments*](https://python-poetry.org/docs/managing-environments#managing-environments) and easily switch between environments via `poetry`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pip install slickml
 brew install gcc
 
 # Linux Users
-sudo apt install build-essential       
+sudo apt install build-essential gfortran
 ```
 
 ### 🐍 Python Virtual Environments


### PR DESCRIPTION
Currently Ubuntu install when contributing fails due to a missing Fortran compiler. Suggest adding `gfortran` as a default.

Steps to reproduce:

```
docker run -it --rm -v $PWD:/app ubuntu:latest
apt-get install python3 python3-pip python3-venv build-essential
python3 -m venv /.venv
source /.venv/bin/activate
pip install poetry
cd /app
poetry install
```