### PR TITLE
Fix API Reference Landing Page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,7 +127,7 @@ Please note that before starting any major work, open an issue describing what y
 
 
 ### 🧪 Testing
-- We believe in [Modern Test Driven Development (TDD)](https://testdriven.io/blog/modern-tdd/) and mainly use [*pydantic*](https://pydantic-docs.helpmanual.io/), [*pytest*](https://docs.pytest.org/en/7.1.x/), [*assertpy*](https://github.com/assertpy/assertpy) along with [*pytest-cov*](https://github.com/pytest-dev/pytest-cov) with more specification laid out in [*.coveragerc*](https://github.com/slickml/slick-ml/blob/master/.coveragerc) to develop our unit-tests.
+- We believe in [Modern Test Driven Development (TDD)](https://testdriven.io/blog/modern-tdd/) and mainly use [*pytest*](https://docs.pytest.org/en/7.1.x/), [*assertpy*](https://github.com/assertpy/assertpy) along with various plugins including [*pytest-cov*](https://github.com/pytest-dev/pytest-cov) with more specification laid out in [*.coveragerc*](https://github.com/slickml/slick-ml/blob/master/.coveragerc) to develop our unit-tests.
 - All unit-tests live in `tests/` directory separted from the source code.
 - All unit-test files should begin with the word `test` i.e. `test_foo.py`.
 - Our naming convention for naming tests is `test_<method_under_test>__<when>__<then>` pattern which would increase the code readbility.
@@ -150,7 +150,7 @@ Please note that before starting any major work, open an issue describing what y
   poe sphinx
   ```
 - The generated API documentation file can be found at `docs/_build/index.html`.
-- You can also add a new page in `.rst` or `md` formats under `docs/page`.
+- You can also add a new page in `.rst` or `md` formats under `docs/pages`.
 - All `sphinx` configurations that we are using are available in `docs/conf.py`.
 
 ## 🔥 Pull Requests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,7 +181,7 @@ autoapi_ignore = [
     "*migrations*",
     "*TODO*",
 ]
-autoapi_add_toctree_entry = True
+autoapi_add_toctree_entry = False
 autoapi_python_class_content = "class"
 autoapi_member_order = "alphabetical"
 autoapi_python_use_implicit_namespaces = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,16 +43,16 @@ of information that can be inferred.
         :link: pages/installation
         :link-type: doc
 
-        Learn more on the requirements and how to set up your Python environment to install SlickML ...
+        Learn more about the requirements and how to set up your Python environment to install SlickML smoothly ...
 
     .. grid-item-card:: :doc:`📌 Quick Start <pages/quick_start>`
         :link: pages/quick_start
         :link-type: doc
 
-        Wanna take a glimpse at some of key functionalities? Quick start is the best place to start your journey ...
+        Wanna take a glimpse at some of the key functionalities? Quick start is the best place to start your journey ...
 
-    .. grid-item-card:: :doc:`🎯 API Reference <autoapi/index>`
-        :link: autoapi/index
+    .. grid-item-card:: :doc:`🎯 API Reference <pages/api>`
+        :link: pages/api
         :link-type: doc
 
         Explore SlickML API Reference and hopefully scrutinize the source code ...
@@ -104,7 +104,7 @@ community. This is a good place to discuss your questions and ideas or in genera
    License <pages/license>
    Code of Conduct <pages/code_of_conduct>
    Contact Us <pages/contact_us>
-   API Reference <autoapi/index>
+   API Reference <pages/api>
 
 .. FUTURE PAGES:
    Examples <pages/examples>

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1,0 +1,67 @@
+.. SlickML documentation API Reference Entry Point
+.. NOTES: 
+   1) This is the landing page of API Reference which is mainly populated via `sphinx auto-api`. The
+      automated API references lives under `<autoapi/index>`.
+   2) This entry point needs maintenance for the cases that we are adding a new upper-level entry
+      point. For example, currently we do not have any `clustering/` methods. Therefore, by adding
+      it to the API, we need to expose it here as a new card.
+
+API Reference
+---------------
+
+.. grid:: 1 2 2 2
+    :gutter: 3
+    :margin: 0
+    :padding: 3 4 0 0
+
+    .. grid-item-card:: 💣 Classification
+        :link: https://www.docs.slickml.com/autoapi/slickml/classification/index.html
+        :link-type: url
+
+        Learn more about the available classifiers ...
+
+    .. grid-item-card:: 🔥 Regression
+        :link: https://www.docs.slickml.com/autoapi/slickml/regression/index.html
+        :link-type: url
+
+        Learn more about the available regressors ...  
+
+    .. grid-item-card:: 🩺 Selection
+        :link: https://www.docs.slickml.com/autoapi/slickml/selection/index.html
+        :link-type: url
+
+        Learn more about the available algorithms for feature selection ...   
+
+    .. grid-item-card:: 🏎 Optimization
+        :link: https://www.docs.slickml.com/autoapi/slickml/optimization/index.html
+        :link-type: url
+
+        Learn more about the available hyper-parameters tuning optimizers ...                        
+
+    .. grid-item-card:: 📈 Metrics
+        :link: https://www.docs.slickml.com/autoapi/slickml/metrics/index.html
+        :link-type: url
+
+        Learn more about the key functionalities to visualize optimized metrics ...
+
+    .. grid-item-card:: 📊 Visualization
+        :link: https://www.docs.slickml.com/autoapi/slickml/visualization/index.html
+        :link-type: url
+
+        Learn more about the key visualization functions that is used across the API ...
+
+    .. grid-item-card:: 🧰 Utils
+        :link: https://www.docs.slickml.com/autoapi/slickml/utils/index.html
+        :link-type: url
+
+        Learn more about the key utility functions that is used across the API ...
+
+    .. grid-item-card:: β Beta
+        :link: https://www.docs.slickml.com/autoapi/slickml/beta/index.html
+        :link-type: url
+
+        Learn more about the experimental functionalities across the API ...  
+
+
+
+

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -116,7 +116,7 @@ Please note that before starting any major work, open an issue describing what y
 
 
 ## 🧪 Testing
-- We believe in [Modern Test Driven Development (TDD)](https://testdriven.io/blog/modern-tdd/) and mainly use [*pydantic*](https://pydantic-docs.helpmanual.io/), [*pytest*](https://docs.pytest.org/en/7.1.x/), [*assertpy*](https://github.com/assertpy/assertpy) along with [*pytest-cov*](https://github.com/pytest-dev/pytest-cov) with more specification laid out in [*.coveragerc*](https://github.com/slickml/slick-ml/blob/master/.coveragerc) to develop our unit-tests.
+- We believe in [Modern Test Driven Development (TDD)](https://testdriven.io/blog/modern-tdd/) and mainly use [*pytest*](https://docs.pytest.org/en/7.1.x/), [*assertpy*](https://github.com/assertpy/assertpy) along with various plugins including [*pytest-cov*](https://github.com/pytest-dev/pytest-cov) with more specification laid out in [*.coveragerc*](https://github.com/slickml/slick-ml/blob/master/.coveragerc) to develop our unit-tests.
 - All unit-tests live in `tests/` directory separted from the source code.
 - All unit-test files should begin with the word `test` i.e. `test_foo.py`.
 - Our naming convention for naming tests is `test_<method_under_test>__<when>__<then>` pattern which would increase the code readbility.
@@ -139,7 +139,7 @@ Please note that before starting any major work, open an issue describing what y
   poe sphinx
   ```
 - The generated API documentation file can be found at `docs/_build/index.html`.
-- You can also add a new page in `.rst` or `md` formats under `docs/page`.
+- You can also add a new page in `.rst` or `md` formats under `docs/pages`.
 - All `sphinx` configurations that we are using are available in `docs/conf.py`.
 
 


### PR DESCRIPTION
<!-- Please check the contributing guidelines before opening a PR -->
<!-- https://github.com/slickml/slick-ml/blob/master/CONTRIBUTING.md -->
<!-- Please join our Slack Channel at https://www.slickml.com/slack-invite if you are interested -->

## Description
- Added a landing page with cards for `API Reference` under `pages/api`.
- More cleanups.

Resolves: #issue-number-here

## Pull Request Checklist

- [ ] Added **tests** for added or changed code.
- [x] Added **documentation** for changed code.
<!-- This should include: updating markdown docs, adding/updating function documentation, etc -->
