### PR TITLE
Add `deprecated` annotation to `slickml.utils`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -75,6 +75,6 @@ exclude =
     .mypy_cache,
     htmlcov/*,
     xmlcov/*,
-    .coverage
-    
+    .coverage,
+    examples/
     

--- a/src/slickml/base/__init__.py
+++ b/src/slickml/base/__init__.py
@@ -3,7 +3,7 @@ from slickml.base._estimator import BaseXGBoostEstimator
 from slickml.base._metrics import Metrics
 
 __all__ = [
+    "BaseXGBoostEstimator",
     "ExtendedEnum",
     "Metrics",
-    "BaseXGBoostEstimator",
 ]

--- a/src/slickml/classification/__init__.py
+++ b/src/slickml/classification/__init__.py
@@ -3,7 +3,7 @@ from slickml.classification._xgboost import XGBoostClassifier
 from slickml.classification._xgboostcv import XGBoostCVClassifier
 
 __all__ = [
+    "GLMNetCVClassifier",
     "XGBoostClassifier",
     "XGBoostCVClassifier",
-    "GLMNetCVClassifier",
 ]

--- a/src/slickml/metrics/__init__.py
+++ b/src/slickml/metrics/__init__.py
@@ -2,6 +2,6 @@ from slickml.metrics._classification import BinaryClassificationMetrics
 from slickml.metrics._regression import RegressionMetrics
 
 __all__ = [
-    "RegressionMetrics",
     "BinaryClassificationMetrics",
+    "RegressionMetrics",
 ]

--- a/src/slickml/regression/__init__.py
+++ b/src/slickml/regression/__init__.py
@@ -3,7 +3,7 @@ from slickml.regression._xgboost import XGBoostRegressor
 from slickml.regression._xgboostcv import XGBoostCVRegressor
 
 __all__ = [
-    "XGBoostRegressor",
-    "XGBoostCVRegressor",
     "GLMNetCVRegressor",
+    "XGBoostCVRegressor",
+    "XGBoostRegressor",
 ]

--- a/src/slickml/utils/__init__.py
+++ b/src/slickml/utils/__init__.py
@@ -1,3 +1,4 @@
+from slickml.utils._annotations import deprecated
 from slickml.utils._format import Colors
 from slickml.utils._transform import (
     add_noisy_features,
@@ -8,10 +9,11 @@ from slickml.utils._transform import (
 from slickml.utils._validation import check_var
 
 __all__ = [
-    "memory_use_csr",
-    "df_to_csr",
-    "array_to_df",
     "add_noisy_features",
+    "array_to_df",
     "check_var",
     "Colors",
+    "deprecated",
+    "df_to_csr",
+    "memory_use_csr",
 ]

--- a/src/slickml/utils/_annotations.py
+++ b/src/slickml/utils/_annotations.py
@@ -1,0 +1,87 @@
+import functools
+import warnings
+from typing import Callable, Optional, TypeVar
+
+# TODO(amir): check when `ParamSpec` will be available in `typing`? I guess it is available for
+# python version >= 3.10 --> https://www.youtube.com/watch?v=fwZoxWyMGM8
+# we might wanna import it in a `try/except block` depending on the python version to be bullet-proof
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def deprecated(
+    alternative: Optional[str] = None,
+    since: Optional[str] = None,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Annotation decorator for marking APIs as deprecated in docstrings and raising a warning if called.
+
+    Parameters
+    ----------
+    alternative : str, optional
+        The name of a superseded replacement function, method, or class to use in place of the
+        deprecated one, by default None
+
+    since : str, optional
+        A version designator defining during which release the function, method, or class was marked
+        as deprecated, by default None
+
+    Returns
+    -------
+    Callable[[Callable[P, R]], Callable[P, R]]
+    """
+
+    def deprecated_decorator(func: Callable[P, R]) -> Callable[P, R]:
+        """Main annotation decorator.
+
+        Parameters
+        ----------
+        func : Callable[P, R]
+            Deprecated function
+
+        Returns
+        -------
+        Callable[P, R]
+        """
+        since_str = f" since {since}" if since else ""
+        warning_message = f"""``{func.__module__}.{func.__qualname__}`` is deprecated{since_str} and will be removed in a future release."""
+        if alternative is not None and alternative.strip():
+            warning_message += f" Use ``{alternative}`` instead."
+
+        @functools.wraps(func)
+        def inner_deprecated_decorator(
+            *args: P.args,
+            **kwargs: P.kwargs,
+        ) -> R:
+            """Inner annotation decorator.
+
+            Parameters
+            ----------
+            *args : P.args
+                Positional arguments of the deprecated function
+
+            **kwargs : P.kwargs
+                Named arguments of the deprecated function
+
+            Returns
+            -------
+            R
+            """
+            warnings.warn(
+                warning_message,
+                category=FutureWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        # TODO(amir): this is currently not working for classes properly
+        if func.__doc__ is not None:
+            inner_deprecated_decorator.__doc__ = (
+                f".. deprecated:: {warning_message}\n{func.__doc__}"
+            )
+        else:
+            inner_deprecated_decorator.__doc__ = f".. deprecated:: {warning_message}\n"
+        return inner_deprecated_decorator
+
+    return deprecated_decorator

--- a/src/slickml/visualization/__init__.py
+++ b/src/slickml/visualization/__init__.py
@@ -14,14 +14,14 @@ from slickml.visualization._xgboost import (
 )
 
 __all__ = [
-    "plot_regression_metrics",
     "plot_binary_classification_metrics",
-    "plot_xgb_cv_results",
-    "plot_xgb_feature_importance",
-    "plot_shap_summary",
-    "plot_shap_waterfall",
     "plot_glmnet_coeff_path",
     "plot_glmnet_cv_results",
+    "plot_regression_metrics",
+    "plot_shap_summary",
+    "plot_shap_waterfall",
     "plot_xfs_cv_results",
     "plot_xfs_feature_frequency",
+    "plot_xgb_cv_results",
+    "plot_xgb_feature_importance",
 ]

--- a/tests/slickml/utils/test_annotations.py
+++ b/tests/slickml/utils/test_annotations.py
@@ -1,0 +1,240 @@
+from dataclasses import dataclass
+
+import pytest
+from assertpy import assert_that
+
+from slickml.utils import deprecated
+
+_X = 1367
+_ALTERNATIVE = "slickml.best()"
+_SINCE = "version 1.2.3"
+
+
+def test_deprecated_function__passes__with_defaults() -> None:
+    """Validates annotating a function with ``deprecated`` decorator and default arguments."""
+
+    @deprecated()
+    def foo(x: int) -> int:
+        """Docstring for function ``foo``."""
+        return x
+
+    with pytest.warns(FutureWarning) as record:
+        r = foo(x=_X)
+
+    assert_that(r).is_instance_of(int)
+    assert_that(r).is_equal_to(_X)
+    assert_that(foo.__doc__).contains(
+        _default_deprecation_warning(),
+    )
+    assert_that(record).is_length(1)
+    assert_that(record[0].message.args[0]).contains(
+        _default_deprecation_warning(),
+    )
+
+
+def test_deprecated_function__passes__with_custom_inputs() -> None:
+    """Validates annotating a function with ``deprecated`` decorator and custom arguments."""
+
+    @deprecated(
+        alternative=_ALTERNATIVE,
+        since=_SINCE,
+    )
+    def foo(x: int) -> int:
+        """Docstring for function ``foo``."""
+        return x
+
+    with pytest.warns(FutureWarning) as record:
+        r = foo(x=_X)
+
+    assert_that(r).is_instance_of(int)
+    assert_that(r).is_equal_to(_X)
+    assert_that(foo.__doc__).contains("Docstring for function ``foo``.")
+    assert_that(foo.__doc__).contains(
+        _custom_deprecation_warning(),
+    )
+    assert_that(record).is_length(1)
+    assert_that(record[0].message.args[0]).contains(
+        _custom_deprecation_warning(),
+    )
+
+
+def test_deprecated_function__passes__with_custom_inputs_and_no_docstring() -> None:
+    """Validates annotating a function with ``deprecated`` decorator and custom arguments."""
+
+    @deprecated(
+        alternative=_ALTERNATIVE,
+        since=_SINCE,
+    )
+    def foo(x: int) -> int:
+        return x
+
+    with pytest.warns(FutureWarning) as record:
+        r = foo(x=_X)
+
+    assert_that(r).is_instance_of(int)
+    assert_that(r).is_equal_to(_X)
+    assert_that(foo.__doc__).contains(
+        _custom_deprecation_warning(),
+    )
+    assert_that(record).is_length(1)
+    assert_that(record[0].message.args[0]).contains(
+        _custom_deprecation_warning(),
+    )
+
+
+def test_deprecated_class__passes__with_defaults() -> None:
+    """Validates annotating a class with ``deprecated`` decorator and default arguments."""
+
+    @deprecated()
+    class Bar:
+        """Docstring for class ``Bar``."""
+
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+    with pytest.warns(FutureWarning) as record:
+        b = Bar(x=_X)
+
+    assert_that(b.x).is_instance_of(int)
+    assert_that(b.x).is_equal_to(_X)
+    assert_that(b.__doc__).contains("Docstring for class ``Bar``.")
+    assert_that(record).is_length(1)
+    assert_that(record[0].message.args[0]).contains(
+        _default_deprecation_warning(),
+    )
+
+
+def test_deprecated_class__passes__with_custom_inputs() -> None:
+    """Validates annotating a class with ``deprecated`` decorator and custom arguments."""
+
+    @deprecated(
+        alternative=_ALTERNATIVE,
+        since=_SINCE,
+    )
+    class Bar:
+        """Docstring for class ``Bar``."""
+
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+    with pytest.warns(FutureWarning) as record:
+        b = Bar(x=_X)
+
+    assert_that(b.x).is_instance_of(int)
+    assert_that(b.x).is_equal_to(_X)
+    assert_that(b.__doc__).contains("Docstring for class ``Bar``.")
+    # `class.__doc__` is currently get wrapped. Uncomment below once the decorator is fixed
+    # assert_that(b.__doc__).contains(
+    #     "is deprecated since version 1.2.3 and will be removed in a future release. Use ``Baz`` instead.",
+    # )
+    assert_that(record).is_length(1)
+    assert_that(record[0].message.args[0]).contains(
+        _custom_deprecation_warning(),
+    )
+
+
+def test_deprecated_dataclass__passes__with_defaults() -> None:
+    """Validates annotating a dataclass with ``deprecated`` decorator and default arguments."""
+
+    @deprecated()
+    @dataclass
+    class Baz:
+        """Docstring for class ``Baz``."""
+
+        x: int
+
+    b = Baz(x=_X)
+
+    assert_that(b.x).is_instance_of(int)
+    assert_that(b.x).is_equal_to(_X)
+    assert_that(b.__doc__).contains("Docstring for class ``Baz``.")
+
+
+def test_deprecated_dataclass__passes__with_custom_inputs() -> None:
+    """Validates annotating a dataclass with ``deprecated`` decorator and default arguments."""
+
+    @deprecated(
+        alternative=_ALTERNATIVE,
+        since=_SINCE,
+    )
+    @dataclass
+    class Baz:
+        """Docstring for class ``Baz``."""
+
+        x: int
+
+    with pytest.warns(FutureWarning) as record:
+        b = Baz(x=_X)
+
+    assert_that(b.x).is_instance_of(int)
+    assert_that(b.x).is_equal_to(_X)
+    assert_that(b.__doc__).contains("Docstring for class ``Baz``.")
+    # `class.__doc__` is currently get wrapped. Uncomment below once the decorator is fixed
+    # assert_that(b.__doc__).contains(
+    #     "is deprecated since version 1.2.3 and will be removed in a future release. Use ``Qux`` instead.",
+    # )
+    assert_that(record).is_length(1)
+    assert_that(record[0].message.args[0]).contains(
+        _custom_deprecation_warning(),
+    )
+
+
+def test_deprecated_method_of_dataclass__passes__with_custom_inputs() -> None:
+    """Validates annotating a dataclass with ``deprecated`` decorator and default arguments."""
+
+    @dataclass
+    class Qux:
+        """Docstring for class ``Qux``."""
+
+        @deprecated(
+            alternative=_ALTERNATIVE,
+            since=_SINCE,
+        )
+        def qux(self, x: int) -> int:
+            """Docstring for method ``qux``."""
+            return x
+
+    with pytest.warns(FutureWarning) as record:
+        q = Qux()
+        r = q.qux(x=_X)
+
+    assert_that(r).is_instance_of(int)
+    assert_that(r).is_equal_to(_X)
+    assert_that(q.__doc__).contains("Docstring for class ``Qux``")
+    # `class.__doc__` is currently get wrapped. Uncomment below once the decorator is fixed
+    # assert_that(q.__doc__).contains(
+    #     "is deprecated since version 1.2.3 and will be removed in a future release. Use ``qux_v2`` instead.",
+    # )
+    assert_that(record).is_length(1)
+    assert_that(record[0].message.args[0]).contains(
+        _custom_deprecation_warning(),
+    )
+
+
+def _default_deprecation_warning() -> str:
+    """Returns default deprecation warning message.
+
+    Returns
+    -------
+    str
+    """
+    return "is deprecated and will be removed in a future release."
+
+
+def _custom_deprecation_warning(
+    alternative: str = _ALTERNATIVE,
+    since: str = _SINCE,
+) -> str:
+    """Returns default deprecation warning message.
+
+    alternative : str
+        Alternative method
+
+    since : str
+        Version that deprecation begins
+
+    Returns
+    -------
+    str
+    """
+    return f"is deprecated since {since} and will be removed in a future release. Use ``{alternative}`` instead."


### PR DESCRIPTION
<!-- Please check the contributing guidelines before opening a PR -->
<!-- https://github.com/slickml/slick-ml/blob/master/CONTRIBUTING.md -->
<!-- Please join our Slack Channel at https://www.slickml.com/slack-invite if you are interested -->

## Description
- Added `@deprecated` decorator as part of `utils._annotations` + unit-tests.
- Sorted the items in `__all__` in `__init__.py` files for the sake of better readability. 
- Added `examples/` to the root `.flake8`.

Resolves: #issue-number-here

## Pull Request Checklist

- [x] Added **tests** for added or changed code.
- [x] Added **documentation** for changed code.
<!-- This should include: updating markdown docs, adding/updating function documentation, etc -->
