### PR TITLE
fix: Re-use poetry cache from CI step for publish docs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
       #----------------------------------------------
       #  -----  install dependencies  -----
       #----------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # TODO(amir): enable `windows-latest`, `macos-latest` and fix possible `poetry` issues and glmnet
+        # TODO(amir): enable `windows-latest` and fix possible `poetry` issues and glmnet
         # TODO(amir): add `"3.12"` once the glmnet wheel is released
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11"]
     steps:
       #----------------------------------------------


### PR DESCRIPTION
<!-- Please check the contributing guidelines before opening a PR -->
<!-- https://github.com/slickml/slick-ml/blob/master/CONTRIBUTING.md -->
<!-- Please join our Slack Channel at https://www.slickml.com/slack-invite if you are interested -->

## Description
- Fixed the poetry cache key in `cd` step to reuse the `ci` step. Also, added `macos` as well for ci.

Resolves: #issue-number-here

## Pull Request Checklist

- [ ] Added **tests** for added or changed code.
- [ ] Added **documentation** for changed code.
<!-- This should include: updating markdown docs, adding/updating function documentation, etc -->
