### PR TITLE
feat: Enable testing with python versions `3.10` and `3.11` via `tox`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -298,7 +298,10 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 xmlcov/
+.pkg/
+.pkg/**
 .tox/
+.tox/**
 .nox/
 .coverage
 .coverage.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,16 +4,18 @@ Hello from SlickML🧞 Team 👋 and welcome to our contributing guidelines 🤗
 
 
 ## 🔗 Quick Links
-  * [Code of Conduct](#️code-of-conduct)
-  * [Getting Started](#getting-started)
-    * [Coding Standards](#coding-standards)
-    * [Environment Management](#environment-management)
-    * [Formatting](#formatting)
-    * [Linting](#linting)
-    * [Testing](#testing)
-    * [Documentation](#documentation)
-    * [Pull Requests](#pull-requests)
-  * [Need Help?](#need-help)
+- [🧑‍💻🤝 Contributing to SlickML🧞](#-contributing-to-slickml)
+  - [🔗 Quick Links](#-quick-links)
+  - [👩‍⚖️  Code of Conduct](#️--code-of-conduct)
+  - [🚀🌙 Getting Started](#-getting-started)
+    - [📐 Coding Standards](#-coding-standards)
+    - [🐍 🥷 Environment Management](#--environment-management)
+    - [🛠 Formatting](#-formatting)
+    - [🪓 Linting](#-linting)
+    - [🧪 Testing](#-testing)
+    - [📖 Documentation](#-documentation)
+  - [🔥 Pull Requests](#-pull-requests)
+  - [❓ 🆘 📲 Need Help?](#---need-help)
 
 
 ## 👩‍⚖️  Code of Conduct
@@ -63,13 +65,13 @@ Please note that before starting any major work, open an issue describing what y
   sudo apt install build-essential gfortran
   ```
 - All developments are done via [*python-poetry*](https://python-poetry.org/). To begin with, first install `poetry` (version >=1.2.0) following the [*installation documentation*](https://python-poetry.org/docs/#installation) depending on your operating system.
-- You can also easily [*manage your Python environments*](https://python-poetry.org/docs/managing-environments#managing-environments) and easily switch between environments via `poetry`. To set the `poetry` environment using your preferred `python` version (i.e. `3.9.13`), which is already installed on your system preferably via `pyenv`, simply run 🏃‍♀️ :
+- You can also easily [*manage your Python environments*](https://python-poetry.org/docs/managing-environments#managing-environments) and easily switch between environments via `poetry`. To set the `poetry` environment using your preferred `python` version (i.e. `3.9.18`), which is already installed on your system preferably via `pyenv`, simply run 🏃‍♀️ :
   ```
-  poetry env use 3.9.13
+  poetry env use 3.9.18
   ```
 - Once you setup your environment, to install the dependencies (`poetry.lock`), simply run 🏃‍♀️ :
   ```
-  poetry install
+  poetry install --all-extras
   ```
 - We mainly use [*Poe the Poet*](https://github.com/nat-n/poethepoet), a pythonic task runner that works well with `poetry`.
 - To make sure your environmnet is setup correctly, simply run 🏃‍♀️ :
@@ -167,7 +169,7 @@ Please note that before starting any major work, open an issue describing what y
      ```
      poe tox
      ```
-     🔔 Sometimes, `tox` is unhappy; so, don't hesitate to run `poe tox` twice 😁 .
+     🔔 Please note that, we are currently running `tox` against `python versions 3.9, 3.10, and 3.11`. Therefore, you can leverage `pyenv` and install these versions and use `pyenv local` command (i.e. `pyenv local 3.9.X 3.10.Y 3.11.Z`) to activate them before running `poe tox`.
   8. Now, you are ready to push your changes to your forked repository.
   9.  Lastly, open a PR in our repository to the `master` branch and follow the PR template so that we can efficiently review the changes as soon as possible and get your feature/bug-fix merged.
   10. Nicely done! You are all set! You are now officially part of [SlickML contributors](https://github.com/slickml/slick-ml/graphs/contributors).

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -52,9 +52,9 @@ Please note that before starting any major work, open an issue describing what y
   sudo apt install build-essential gfortran
   ```
 - All developments are done via [*python-poetry*](https://python-poetry.org/). To begin with, first install `poetry` (version >=1.2.0) following the [*installation documentation*](https://python-poetry.org/docs/#installation) depending on your operating system.
-- You can also easily [*manage your Python environments*](https://python-poetry.org/docs/managing-environments#managing-environments) and easily switch between environments via `poetry`. To set the `poetry` environment using your preferred `python` version (i.e. `3.9.13`) which is already installed on your system preferably via `pyenv`, simply run 🏃‍♀️ :
+- You can also easily [*manage your Python environments*](https://python-poetry.org/docs/managing-environments#managing-environments) and easily switch between environments via `poetry`. To set the `poetry` environment using your preferred `python` version (i.e. `3.9.18`) which is already installed on your system preferably via `pyenv`, simply run 🏃‍♀️ :
   ```
-  poetry env use 3.9.13
+  poetry env use 3.9.18
   ```
 - Once you setup your environment, to install the dependencies (`poetry.lock`), simply run 🏃‍♀️ :
   ```

--- a/docs/pages/installation.md
+++ b/docs/pages/installation.md
@@ -36,7 +36,7 @@ or ``-h`` command. For example, to see all available commands, simply run 🏃�
 - In order to avoid any potential conflicts with other installed Python packages, it is
 recommended to use a virtual environment, e.g. [python poetry](https://python-poetry.org/), [python virtualenv](https://docs.python.org/3/library/venv.html), [pyenv virtualenv](https://github.com/pyenv/pyenv-virtualenv), or [conda environment](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html).
 - We highly recommend to manage your projects using `python-poetry`. All **SlickML** developments are done via [*python-poetry*](https://python-poetry.org/). To begin with, first install `poetry` following the [*installation documentation*](https://python-poetry.org/docs/#installation) depending on your operating system.
-- You can also easily [*manage your Python environments*](https://python-poetry.org/docs/managing-environments#managing-environments) and easily switch between environments via `poetry`. To set the `poetry` environment using your preferred `python` version (i.e. `3.9.13`) which is already installed on your system preferably via `pyenv`, simply run 🏃‍♀️ :
+- You can also easily [*manage your Python environments*](https://python-poetry.org/docs/managing-environments#managing-environments) and easily switch between environments via `poetry`. To set the `poetry` environment using your preferred `python` version (i.e. `3.9.18`) which is already installed on your system preferably via `pyenv`, simply run 🏃‍♀️ :
   ```
-  poetry env use 3.9.13
+  poetry env use 3.9.18
   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ cmd = """
            dist/ 
            .mypy_cache/ 
            .pytest_cache/
-           .tox/
+           .tox
            htmlcov/
            xmlcov/
            **/__pycache__/
@@ -202,7 +202,7 @@ cmd = "poetry run sphinx-build -b html docs/ docs/_build"
 
 [tool.poe.tasks.tox]
 help = "Test environments via tox"
-cmd = "poetry run tox -c tox.ini ."
+cmd = "poetry run tox --conf=tox.ini --root=."
 
 [tool.poe.tasks.format]
 help = "Apply all formatting steps."

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,9 @@
 
 [tox]
 isolated_build = True
-envlist = py39
+# TODO(amir): add `3.12` once glmnet adds the wheel.
+# https://github.com/replicahq/python-glmnet/issues/5
+envlist = py{39,310,311}
 
 [testenv]
 allowlist_externals = poetry
@@ -20,4 +22,3 @@ commands =
     poe test
     poe sphinx
     poetry build
-    poe clean


### PR DESCRIPTION
<!-- Please check the contributing guidelines before opening a PR -->
<!-- https://github.com/slickml/slick-ml/blob/master/CONTRIBUTING.md -->
<!-- Please join our Slack Channel at https://www.slickml.com/slack-invite if you are interested -->

## Description
- Previously, we only had `python 3.9` in `tox`. Therefore, the developer only could see the testing in CI. In this way, we streamlined the python testing against versions 3.9, 3.10, and 3.11 via tox.

Resolves: #issue-number-here

## Pull Request Checklist

- [ ] Added **tests** for added or changed code.
- [x] Added **documentation** for changed code.
<!-- This should include: updating markdown docs, adding/updating function documentation, etc -->
