### PR TITLE
feat: Update landing with slickbet

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -69,14 +69,17 @@
       }
 
       .cards {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
         gap: 1.25rem;
       }
 
       .card {
         display: flex;
         flex-direction: column;
+        flex: 0 1 240px;
+        width: 240px;
         gap: 0.75rem;
         padding: 1.35rem 1.4rem;
         background: color-mix(in srgb, var(--surface) 88%, transparent);
@@ -95,6 +98,7 @@
       .card h2 {
         margin: 0;
         font-size: 1.15rem;
+        text-align: center;
       }
 
       .card p {
@@ -147,6 +151,12 @@
         <a class="card" href="https://www.docs.slickml.com/slick-tune/">
           <h2>SlickTune 🧩</h2>
           <p>Composable LLM fine-tuning utilities.</p>
+          <span>Open docs →</span>
+        </a>
+
+        <a class="card" href="https://www.docs.slickml.com/slick-bet/">
+          <h2>SlickBet ⚽</h2>
+          <p>Livescore screener for better bets.</p>
           <span>Open docs →</span>
         </a>
 


### PR DESCRIPTION
## Summary
- Add a **SlickBet ⚽** card on the docs hub linking to `https://www.docs.slickml.com/slick-bet/`
- Keep all four libraries, with **AFK-Bot** last: SlickML → SlickTune → SlickBet → AFK-Bot
- Center card titles and use a centered flex wrap so the last card stays centered when alone on a row

